### PR TITLE
VCS Support

### DIFF
--- a/SIMULATOR_SETUP
+++ b/SIMULATOR_SETUP
@@ -2,6 +2,7 @@ Quick start instructions for various simulators:
 
 A) modelsim_ase (Free version for ModelSim with Quartus)
 B) NCsim
+C) VCS
 
 
 A) modelsim_ase
@@ -60,3 +61,21 @@ B) NCsim
 
 	6) At this point the simulator will be waiting for pslse to connect.
 		Refer back to QUICK_START for those instructions.
+
+C) VCS
+	1) Set the VPI_USER_H_DIR environment variable to
+		"$VCS_HOME/`vcs -platform`/lib"
+
+	2) Comment out the VLI instatiation code in afu_driver.c
+
+	3) Use vcs to compile afu_driver.c, psl_interface.c, top.v, as well as
+		your AFU HDL files. The following command has been tested and
+		works:
+		
+		$VCS_HOME/bin/vcs -q -sverilog -gui -R -file ./pslse/vcs_include ./pslse/afu_driver/src/afu_driver.c ./pslse/common/psl_interface.c +vpi ./pslse/afu_driver/verilog/top.v [path to your AFU]		
+
+		When invoked from the parent directory of PSLSE [eg. ~/project/], 
+		this will compile the necessary C files, as well as include 
+		the needed header files, compile your AFU source code 
+		(additional flags may need to be passed for VHDL), link 
+		everything, then run the simulation with a gui.

--- a/afu_driver/verilog/top.tab
+++ b/afu_driver/verilog/top.tab
@@ -1,0 +1,8 @@
+$afu_init call=afu_init
+$register_clock call=register_clock
+$register_control call=register_control
+$register_mmio call=register_mmio
+$register_command call=register_command
+$register_rd_buffer call=register_rd_buffer
+$register_wr_buffer call=register_wr_buffer
+$register_response call=register_response

--- a/pslse/pslse.parms
+++ b/pslse/pslse.parms
@@ -20,7 +20,7 @@
 # NOTE: Must be a single value, not a min,max range
 #CREDITS:64
 
-# Randomization seed.  Set this to force reproducable sequence of event
+# Randomization seed.  Set this to force reproducible sequence of event
 # NOTE: Must be a single value, not a min,max range
 SEED:13
 

--- a/vcs_include
+++ b/vcs_include
@@ -1,0 +1,3 @@
+-CFLAGS '-I[absolute path to /pslse/common]'
+-CFLAGS '-I$VCS_HOME/`vcs -platform`/lib'
+-P ./pslse/afu_driver/verilog/top.tab


### PR DESCRIPTION
vcs_include was needed for me to avoid problematic syntax when compiling
AFU.

By parent directory I mean if you did a git clone to ~/project/, then
project would be the parent directory of pslse.