### PR TITLE
added types to declaration for _aligned

### DIFF
--- a/pslse/cmd.c
+++ b/pslse/cmd.c
@@ -247,7 +247,7 @@ static void _add_other(struct cmd *cmd, uint32_t handle, uint32_t tag,
 }
 
 // Check address alignment
-static int _aligned(addr, size)
+static int _aligned(uint64_t addr, uint32_t size)
 {
 	// Check valid size
 	if ((size == 0) || (size & (size - 1))) {


### PR DESCRIPTION
Fixes #35

Since this function did not have it's argument types declared, when built for 32bit architecture the inputs of this function are truncated. This should fix it for 32-bit builds.