### PR TITLE
Add fake function to do sigbus handling

### DIFF
--- a/libcxl/libcxl.h
+++ b/libcxl/libcxl.h
@@ -253,6 +253,7 @@ cxl_get_cr_vendor(struct cxl_afu_h *afu __attribute__((unused)),
 static inline int cxl_mmio_install_sigbus_handler(void)
 {
 	/* nothing to be done yet */
+	return 0;
 }
 
 #endif

--- a/libcxl/libcxl.h
+++ b/libcxl/libcxl.h
@@ -242,4 +242,17 @@ cxl_get_cr_vendor(struct cxl_afu_h *afu __attribute__((unused)),
 	return 0;
 }
 
+/*
+ * Calling this function will install the libcxl SIGBUS handler. This will
+ * catch bad MMIO accesses (e.g. due to hardware failures) that would otherwise
+ * terminate the program and make the above mmio functions return errors
+ * instead.
+ *
+ * Call this once per process prior to any MMIO accesses.
+ */
+static inline int cxl_mmio_install_sigbus_handler(void)
+{
+	/* nothing to be done yet */
+}
+
 #endif


### PR DESCRIPTION
In our latest code I am using the sigbus handling function in libcxl. The simulation version is missing this yet.
We like to read registers, were reading might fail due to injected errors. In this case I do not want the library to call abort() to stop the application, but instead log the error nicely before we quit.