### PR TITLE
Fix what looks like a thinko in _handle_afu

### DIFF
--- a/pslse/psl.c
+++ b/pslse/psl.c
@@ -420,7 +420,7 @@ static void _handle_afu(struct psl *psl)
 		for (i = 0; i < psl->max_clients; i++) {
 			if (psl->client[i] == NULL)
 				continue;
-			client_drop(client, PSL_IDLE_CYCLES, CLIENT_NONE);
+			client_drop(psl->client[i], PSL_IDLE_CYCLES, CLIENT_NONE);
 		}
 	  }
 	}


### PR DESCRIPTION
This code causes a compiler warning, and on inspection appears to be a thinko. This is a possible fix, but I don't entirely understand the context.