### PR TITLE
Allow hardcoded paths to be overriden by environment variables.

### DIFF
--- a/libcxl/libcxl.c
+++ b/libcxl/libcxl.c
@@ -724,6 +724,7 @@ static void *_psl_loop(void *ptr)
 
 static int _pslse_connect(uint16_t * afu_map, int *fd)
 {
+	char *pslse_server_dat_path;
 	FILE *fp;
 	uint8_t buffer[MAX_LINE_CHARS];
 	struct sockaddr_in ssadr;
@@ -733,7 +734,9 @@ static int _pslse_connect(uint16_t * afu_map, int *fd)
 
 	// Get hostname and port of PSLSE server
 	DPRINTF("AFU CONNECT\n");
-	fp = fopen("pslse_server.dat", "r");
+	pslse_server_dat_path = getenv("PSLSE_SERVER_DAT");
+	if (!pslse_server_dat_path) pslse_server_dat_path = "pslse_server.dat";
+	fp = fopen(pslse_server_dat_path, "r");
 	if (!fp) {
 		perror("fopen:pslse_server.dat");
 		goto connect_fail;

--- a/pslse/pslse.c
+++ b/pslse/pslse.c
@@ -522,6 +522,7 @@ int main(int argc, char **argv)
 	socklen_t client_len;
 	sigset_t set;
 	struct sigaction action;
+	char *parms_path;
 	struct parms *parms;
 	char *ip;
 
@@ -547,9 +548,11 @@ int main(int argc, char **argv)
 	debug_send_version(fp, PSLSE_VERSION_MAJOR, PSLSE_VERSION_MINOR);
 
 	// Parse parameters file
-	parms = parse_parms("pslse.parms", fp);
+	parms_path = getenv("PSLSE_PARMS")
+	if (!parms_path) parms_path = "pslse.parms";
+	parms = parse_parms(parms_path, fp);
 	if (parms == NULL) {
-		error_msg("Unable to parse pslse.parms file");
+		error_msg("Unable to parse params file \"%s\"", parms_path);
 		return -1;
 	}
 	timeout = parms->timeout;


### PR DESCRIPTION
For our environment, hard-coded paths impose some difficulties.  I've added code that allows the hard-coded paths to be over-ridden using environment variables, without changing the default functionality.