### PR TITLE
Override file paths with environment variables

### DIFF
--- a/QUICK_START
+++ b/QUICK_START
@@ -1,6 +1,5 @@
 PSLSE Quick Start Guide
 
-
 SETUP:
 
 1) Use "make" to build the code in afu_driver/src.  You will have to first set
@@ -45,25 +44,36 @@ SETUP:
 RUNNING:
 
 1) Start your simulator with the model that uses top.v as it's top level and
-	uses the afu_driver/src code for VPI functions.  You should get a
-	message in the simulator output similiar to this:
-	"AFU Server is waiting for connection on machine.domain.com:32768"
+   uses the afu_driver/src code for VPI functions.  You should get a message in
+   the simulator output similiar to this: "AFU Server is waiting for connection
+   on machine.domain.com:32768"
 
 2) Edit pslse/shim_host.dat to point an AFU at your simulator.  For example:
-	afu0.0,machine.domain.com:32768
+     afu0.0,machine.domain.com:32768
+   If necessary, set the SHIM_HOST_DAT environment variable to override the
+   path to this file.
 
 3) Edit pslse/pslse.parms as desired, or leave the defaults to get started.
+   If necessary, override the path to this file using the PSLSE_PARMS
+   environment variable.
 
-4) Start pslse with ./pslse in pslse directory.  You will see a message from
-	pslse with a hostname and port similiar to this:
-	"INFO : Started PSLSE server, listening on machine.domain.com:16384"
+4) Optional: If you need to specify a non-default path for configuration or log
+   files, use these environment variables:
+     SHIM_HOST_DAT: specifies path to the `shim_host.dat` file.
+     PSLSE_PARMS: specifies path to the `pslse.parms` file.
 
-5) In the directory where you will run your application code create the file
-	pslse_server.dat and put the host:port provided by pslse in it.
-	For example:
-	machine.domain.com:16384
+5) Start pslse with ./pslse in pslse directory.  You will see a message from
+   pslse with a hostname and port similiar to this:
+     "INFO : Started PSLSE server, listening on machine.domain.com:16384"
 
-6) Start your application.  Run your application multiple times if desired.
+6) In the directory where you will run your application code create the file
+   pslse_server.dat and put the host:port provided by pslse in it.  For
+   example:
+     machine.domain.com:16384
 
-7) When run is complete you can stop pslse executable with Ctrl-C to cleanly
-	disconnect from the simulator.
+7) Start your application.  Run your application multiple times if desired.
+   If necessary, override the path to the `pslse_server.dat` file using the
+   PSLSE_SERVER_DAT environment variable.
+
+8) When run is complete you can stop pslse executable with Ctrl-C to cleanly
+   disconnect from the simulator.

--- a/common/psl_interface.c
+++ b/common/psl_interface.c
@@ -90,8 +90,11 @@ static int establish_protocol(struct AFU_EVENT *event)
 	}
 	while (bp < bl) {
 		bc = send(event->sockfd, event->tbuf + bp, bl - bp, 0);
-		if (bc < 0)
+		if (bc < 0) {
+			fprintf(stderr, "ERROR: establish_protocol: send failed: %s\n",
+							strerror(errno));
 			return PSL_TRANSMISSION_ERROR;
+		}
 		bp += bc;
 	}
 
@@ -116,8 +119,16 @@ static int establish_protocol(struct AFU_EVENT *event)
 	}
 	event->rbp = 0;
 
-	if (strcmp((char *)event->rbuf, "PSL"))
+	if (strcmp((char *)event->rbuf, "PSL") != 0) {
+		if (strcmp((char *)event->rbuf, "PSLSE") == 0) {
+			fprintf(stderr, "ERROR: establish_protocol: PSLSE client attempted"
+							" to connect directly, instead of relaying through the"
+							" pslse server.\n");
+		} else {
+			fprintf(stderr, "ERROR: establish_protocol: Unrecognized protocol.\n");
+		}
 		return PSL_BAD_SOCKET;
+	}
 
 	primary = 0;
 	for (i = 4; i < 8; i++) {

--- a/pslse/psl.c
+++ b/pslse/psl.c
@@ -758,18 +758,21 @@ uint16_t psl_init(struct psl **head, struct parms *parms, char *id, char *host,
 	debug_afu_connect(psl->dbg_fp, psl->dbg_id);
 
 	// Initialize job handler
+	debug_msg("%s @ %s:%d: job_init", psl->name, psl->host, psl->port);
 	if ((psl->job = job_init(psl->afu_event, &(psl->state), psl->name,
 				 psl->dbg_fp, psl->dbg_id)) == NULL) {
 		perror("job_init");
 		goto init_fail;
 	}
 	// Initialize mmio handler
+	debug_msg("%s @ %s:%d: mmio_init", psl->name, psl->host, psl->port);
 	if ((psl->mmio = mmio_init(psl->afu_event, psl->timeout, psl->name,
 				   psl->dbg_fp, psl->dbg_id)) == NULL) {
 		perror("mmio_init");
 		goto init_fail;
 	}
 	// Initialize cmd handler
+	debug_msg("%s @ %s:%d: cmd_init", psl->name, psl->host, psl->port);
 	if ((psl->cmd = cmd_init(psl->afu_event, parms, psl->mmio,
 				 &(psl->state), psl->name, psl->dbg_fp,
 				 psl->dbg_id))
@@ -806,12 +809,15 @@ uint16_t psl_init(struct psl **head, struct parms *parms, char *id, char *host,
 	*head = psl;
 
 	// Send reset to AFU
+	debug_msg("%s @ %s:%d: Sending reset job.", psl->name, psl->host, psl->port);
 	reset = add_job(psl->job, PSL_JOB_RESET, 0L);
 	while (psl->job->job == reset) {	/*infinite loop */
 		lock_delay(psl->lock);
 	}
 
 	// Read AFU descriptor
+	debug_msg("%s @ %s:%d: Reading AFU descriptor.", psl->name, psl->host,
+	          psl->port);
 	psl->state = PSLSE_DESC;
 	read_descriptor(psl->mmio, psl->lock);
 

--- a/pslse/pslse.c
+++ b/pslse/pslse.c
@@ -522,12 +522,16 @@ int main(int argc, char **argv)
 	socklen_t client_len;
 	sigset_t set;
 	struct sigaction action;
+	char *shim_host_path;
 	char *parms_path;
+	char *debug_log_path;
 	struct parms *parms;
 	char *ip;
 
 	// Open debug.log file
-	fp = fopen("debug.log", "w");
+	debug_log_path = getenv("DEBUG_LOG_PATH");
+	if (!debug_log_path) debug_log_path = "debug.log";
+	fp = fopen(debug_log_path, "w");
 	if (!fp) {
 		error_msg("Could not open debug.log");
 		return -1;
@@ -564,7 +568,9 @@ int main(int argc, char **argv)
 	// Connect to simulator(s) and start psl thread(s)
 	pthread_mutex_init(&lock, NULL);
 	pthread_mutex_lock(&lock);
-	afu_map = parse_host_data(&psl_list, parms, "shim_host.dat", &lock, fp);
+	shim_host_path = getenv("SHIM_HOST_DAT");
+	if (!shim_host_path) shim_host_path = "shim_host.dat";
+	afu_map = parse_host_data(&psl_list, parms, shim_host_path, &lock, fp);
 	if (psl_list == NULL) {
 		free(parms);
 		fclose(fp);


### PR DESCRIPTION
"debug.log" and "host_shims.dat" can now be optionally overridden using environment variables.
Added documentation of environment variables to QUICK_START.
Added some debug_msg calls that were useful to me when debugging my AFU, that might also be useful to others.