### PR TITLE
readded libcxl.so to libcxl build

### DIFF
--- a/libcxl/Makefile
+++ b/libcxl/Makefile
@@ -5,8 +5,7 @@ include Makefile.rules
 
 OBJS = libcxl.o debug.o utils.o
 
-#all: $(COMMON_DIR)/misc/cxl.h libcxl.so libcxl.a
-all: $(COMMON_DIR)/misc/cxl.h libcxl.a
+all: $(COMMON_DIR)/misc/cxl.h libcxl.so libcxl.a
 
 CHECK_HEADER = $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null 2>&1 && echo y || echo n)
 
@@ -15,8 +14,8 @@ ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),n)
 	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 endif
 
-#libcxl.so: $(OBJS)
-#	$(call Q,CC, $(CC) $(CFLAGS) -shared $^ -o $@, $@) -Wl,--version-script symver.map
+libcxl.so: $(OBJS)
+	$(call Q,CC, $(CC) $(CFLAGS) -shared $^ -o $@, $@) -Wl,--version-script symver.map
 
 libcxl.a: $(OBJS)
 	$(call Q,AR, $(AR) rcs $@ $^, $@)


### PR DESCRIPTION
The libcxl shared lib was commented out some time ago, this removes the comment to include it in the libcxl build once more.

Fixes #60

