### PR TITLE
Fixup make problem

### DIFF
--- a/libcxl/Makefile
+++ b/libcxl/Makefile
@@ -5,7 +5,7 @@ include Makefile.rules
 
 OBJS = libcxl.o debug.o utils.o
 
-all: $(COMMON_DIR)/misc/cxl.h libcxl.so libcxl.a
+all: libcxl.so libcxl.a
 
 CHECK_HEADER := $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null 2>&1 && echo y || echo n)
 
@@ -13,6 +13,8 @@ $(COMMON_DIR)/misc/cxl.h:
 ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),n)
 	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 endif
+
+libcxl.o: $(COMMON_DIR)/misc/cxl.h
 
 libcxl.so: $(OBJS)
 	$(call Q,CC, $(CC) $(CFLAGS) -shared $^ -o $@, $@) -Wl,--version-script symver.map

--- a/libcxl/Makefile
+++ b/libcxl/Makefile
@@ -7,7 +7,7 @@ OBJS = libcxl.o debug.o utils.o
 
 all: $(COMMON_DIR)/misc/cxl.h libcxl.so libcxl.a
 
-CHECK_HEADER = $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null 2>&1 && echo y || echo n)
+CHECK_HEADER := $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null 2>&1 && echo y || echo n)
 
 $(COMMON_DIR)/misc/cxl.h:
 ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),n)


### PR DESCRIPTION
Please have a look. Joerg wanted to call make clean all in one line and it did not work. With the 1st fixe proposed here, it should work. Our intuition that the checking of cxl.h's existence was not really working well, was right. Still we are not sure if our adding ":=" instead of "=" is fixing this once and forever. Please review and try, before you accept. Thanks.
