### PR TITLE
parity fix and additions to symver.map

### DIFF
--- a/afu_driver/src/afu_driver.c
+++ b/afu_driver/src/afu_driver.c
@@ -700,7 +700,7 @@ void psl_bfm(const svLogic       ha_pclock, 		// used as pclock on PLI
 	  parity = (uint32_t) event.buffer_wparity[0];
 	  parity <<= 8;
 	  parity += (uint32_t) event.buffer_wparity[1];
-          parity = htons((uint16_t) parity);
+          // parity = htons((uint16_t) parity);  // we don't need to do this as we processed parity byte-wise rather than as an int
 	  setDpiSignal32(ha_bwtag_top, event.buffer_write_tag, 8);
 	  *ha_bwtagpar_top = event.buffer_write_tag_parity;
 	  setMyCacheLine(ha_bwdata_top, event.buffer_wdata);

--- a/libcxl/symver.map
+++ b/libcxl/symver.map
@@ -18,8 +18,15 @@ LIBCXL_1 {
 
 		cxl_get_api_version;
 		cxl_get_api_version_compatible;
+		cxl_get_cr_device;
+		cxl_get_cr_vendor;
+		cxl_get_cr_class;
 		cxl_get_irqs_max;
 		cxl_get_irqs_min;
+
+		cxl_errinfo_size;
+		cxl_errinfor_read;
+
 		cxl_pending_event;
 		cxl_read_event;
 		cxl_read_expected_event;


### PR DESCRIPTION
during the port to using system verilog's DPI, an extra htons() call snuck into the bwpar path.  removed a line of code with a comment about why it is not necessary.