### PR TITLE
Issue80 - update to interrupt modeling

### DIFF
--- a/libcxl/libcxl_internal.h
+++ b/libcxl/libcxl_internal.h
@@ -55,7 +55,7 @@ struct mmio_req {
 struct cxl_afu_h {
 	pthread_t thread;
 	pthread_mutex_t event_lock;
-	struct cxl_event *events[EVENT_QUEUE_MAX];
+        struct cxl_event **events;
 	int adapter;
 	char *id;
 	uint16_t context;

--- a/pslse/cmd.c
+++ b/pslse/cmd.c
@@ -766,7 +766,8 @@ void handle_interrupt(struct cmd *cmd)
 
 	// Send interrupt to client
 	buffer[0] = PSLSE_INTERRUPT;
-	irq = htons(cmd->irq);
+	irq = htons(event->addr);  // addr holds the irq during an intreq command
+	// irq = htons(cmd->irq);  // this was the old way and would essentially convert subsequent interrupt irqs to the first one
 	memcpy(&(buffer[1]), &irq, 2);
 	event->abort = &(client->abort);
 	debug_msg("%s:INTERRUPT irq=%d", cmd->afu_name, cmd->irq);

--- a/pslse/cmd.c
+++ b/pslse/cmd.c
@@ -1096,6 +1096,9 @@ void handle_response(struct cmd *cmd)
 		debug_cmd_response(cmd->dbg_fp, cmd->dbg_id, event->tag);
 		if ((client != NULL) && (event->command == PSL_COMMAND_RESTART))
 			client->flushing = FLUSH_NONE;
+		// clear the irq if we just responded to an intreq
+		if ((client != NULL) && (event->command == PSL_COMMAND_INTREQ))
+		        cmd->irq = 0;
 		*head = event->_next;
 		free(event->data);
 		free(event->parity);

--- a/test/tests/Makefile
+++ b/test/tests/Makefile
@@ -15,7 +15,7 @@ CHECK_HEADER = $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null
 
 misc/cxl.h:
 ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),n)
-	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
+	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s http://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 endif
 
 .SECONDEXPANSION:


### PR DESCRIPTION
bring in the changes to fix the behavior of multiple interrupts from branch issue80.  interrupt modeling now allows multiple interrupts as long as the interrupt address is different.  multiple interrupts to the same interrupt address are coalesced to a single interrrupt.