### PR TITLE
Symver: Add forgotten cxl_event_pendig

### DIFF
--- a/libcxl/symver.map
+++ b/libcxl/symver.map
@@ -29,6 +29,7 @@ LIBCXL_1 {
 		cxl_errinfo_size;
 		cxl_errinfor_read;
 
+		cxl_event_pending;
 		cxl_pending_event;
 		cxl_read_event;
 		cxl_read_expected_event;


### PR DESCRIPTION
Linking dynamically fails due to missing symbol.

Signed-off-by: Frank Haverkamp <haver@linux.vnet.ibm.com>