### PR TITLE
CAPI2 integration into PSLSE

### DIFF
--- a/QUICK_START
+++ b/QUICK_START
@@ -5,9 +5,9 @@ Environment Variable Setting:
 This code checkout would run well for PSL8 based AFU verification as well as for PSL9 based verification
 Ensure that the following environment variable setting is done based on the usage
 	for PSL8 based AFU verification, ensure that (for kshell windows) all xterms have this setting:
-	export PSL8=1
+	export PSLVER=8
 	for PSL9 based AFU verification, ensure that (for kshell windows) all xterms have this setting:
-	export PSL9=1
+	export PSLVER=9
 
 	CAUTION:	if we have both PSL8 and PSL9 environment variables set on a window, we will end up with undesired results.
 

--- a/QUICK_START
+++ b/QUICK_START
@@ -9,8 +9,6 @@ Ensure that the following environment variable setting is done based on the usag
 	for PSL9 based AFU verification, ensure that (for kshell windows) all xterms have this setting:
 	export PSLVER=9
 
-	CAUTION:	if we have both PSL8 and PSL9 environment variables set on a window, we will end up with undesired results.
-
 SETUP:
 
 1) Use "make" to build the code in afu_driver/src.  You will have to first set

--- a/QUICK_START
+++ b/QUICK_START
@@ -27,13 +27,13 @@ SETUP:
 	Verilog.  Build a model as required for your simulator.  You may need to set flags
 	or options to allow SystemVerilog keywords as top.v include references to
 	C code that uses SystemVerilog DPI functionality.
+	The libdpi.so created in the previous step should be pointed to for compile.
+	For ease of operation, suggest creation of a softlink to the $PSLSE_INSTALL_DIR/afu_driver/src/libdpi.so
 	NOTE: when compiling the top.v, ensure that proper "define" is passed on, based on the usage
 	ie, for PSL8 based AFU verification "-define PSL8" must be provided to the compiler
 	for PSL9 based AFU verification "-define PSL9" must be provided.
 
-3) Use "make" to compile the code in the directory pslse. You will have to first
-        set the appropriate #define in common/psl_interface_t.h to select the PSL
-        version you want to work with; be sure to do a "make clean" before your make. 
+3) Use "make" to compile the code in the directory pslse. 
 	This creates a stand-alone executable that mimics the behavior of 
 	PSL/CAPP and the kernel code that supports it.
 
@@ -41,7 +41,10 @@ SETUP:
 	libcxl.a archive library version of libcxl as well as libcxl.so shared
 	object version of libcxl.
 
-5) Look at the Makefiles in sample_app for examples of how to build your
+5) On the Simulation window, ensure that your LD_LIBRARY_PATH env
+	variable has these paths in it - $PSLSE_INSTALL_DIR/libcxl:$PSLSE_INSTALL_DIR/afu_driver/src
+
+6) Look at the Makefiles in sample_app for examples of how to build your
 	application with libcxl.  If you build with libcxl.so then you don't
 	have to re-compile your application if libcxl changes.  You can just
 	re-compile libcxl and libcxl.so is picked up at runtime.  However, this
@@ -49,13 +52,12 @@ SETUP:
 	the libcxl path at runtime.  Alternatively, you can compile with
 	libcxl.a.  When using libcxl.a you don't need to set any environment
 	variables but you do need to recompile your application any time that
-	libcxl is recompiled. for example, ensure that your LD_LIBRARY_PATH env
-	variable has these paths in it - $PSLSE_INSTALL_DIR/libcxl:$PSLSE_INSTALL_DIR/afu_driver/src
+	libcxl is recompiled. 
 
-6) Use sample_app/app.c as an example to start coding your application with
+7) Use sample_app/app.c as an example to start coding your application with
 	libcxl calls using the functions in libcxl.h.
 
-7) Build your application.
+8) Build your application.
 
 
 RUNNING:

--- a/README
+++ b/README
@@ -2,6 +2,18 @@
 | Power Service Layer Simulation Engine |
 +---------------------------------------+
 
+
+*** ATTENTION ATTENTION ATTENTION ATTENTION ***
+
+PSLSE now supports either the Power8 implementation of PSL or the Power9 implementation
+of PSL.  This is controlled by environment variables:
+
+PSL8=1 causes us to compile for the Power8 implementation
+PSL9=1 causes us to compile for the Power9 implementation
+
+You may not set them both at the same time.  This may change in the near future.
+Be sure to review the QUICKSTART file for more detail.
+
 This repository contains code for simulation and testing of a customer designed 
 Accelerated Functional Unit (AFU) and it's accompanying application by
 simulating the connection to the Power Service Layer (PSL) as part of IBM's

--- a/README
+++ b/README
@@ -6,12 +6,12 @@
 *** ATTENTION ATTENTION ATTENTION ATTENTION ***
 
 PSLSE now supports either the Power8 implementation of PSL or the Power9 implementation
-of PSL.  This is controlled by environment variables:
+of PSL.  This is controlled by environment variable PSLVER:
 
-PSL8=1 causes us to compile for the Power8 implementation
-PSL9=1 causes us to compile for the Power9 implementation
+PSLVER=8 causes us to compile for the Power8 implementation
+PSLVER=9 causes us to compile for the Power9 implementation
 
-You may not set them both at the same time.  This may change in the near future.
+You may not set them both at the same time.
 Be sure to review the QUICKSTART file for more detail.
 
 This repository contains code for simulation and testing of a customer designed 

--- a/README
+++ b/README
@@ -11,7 +11,8 @@ of PSL.  This is controlled by environment variable PSLVER:
 PSLVER=8 causes us to compile for the Power8 implementation
 PSLVER=9 causes us to compile for the Power9 implementation
 
-You may not set them both at the same time.
+You must also pass a define into the verilog compile for top.v!
+
 Be sure to review the QUICKSTART file for more detail.
 
 This repository contains code for simulation and testing of a customer designed 

--- a/afu_driver/src/Makefile
+++ b/afu_driver/src/Makefile
@@ -27,6 +27,7 @@ ifndef VPI_USER_H_DIR
   $(error Must set VPI_USER_H_DIR to point to include path for the simulator)
 endif
 
+
 all: veriuser.sl libdpi.so \
 	set_env
 

--- a/afu_driver/src/Makefile.vars
+++ b/afu_driver/src/Makefile.vars
@@ -23,10 +23,12 @@ ifdef FINISH
   CFLAGS += -DFINISH
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
-
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/afu_driver/src/afu_driver.c
+++ b/afu_driver/src/afu_driver.c
@@ -350,11 +350,13 @@ void psl_bfm(const svLogic       ha_pclock, 		// used as pclock on PLI
 	    printf("%08lld: ", (long long) c_sim_time);
 	    printf("ah_brlat_top has either X or Z value =0x%08llx\n", (long long)c_ah_brlat);
           }
+#ifndef PSL8
           else if(c_ah_brlat > 2)
           {
 	    printf("%08lld: ", (long long) c_sim_time);
 	    printf(" WARNING!! ah_brlat has a value other than what is supported on CAIA2. Current value=0x%02llx\n", (long long)c_ah_brlat);
           }
+#endif             
 #ifdef PSL8
           c_ah_jyield    = (ah_jyield & 0x2) ? 0 : (ah_jyield & 0x1);
 #else

--- a/debug/Makefile.vars
+++ b/debug/Makefile.vars
@@ -16,3 +16,11 @@ ifdef DEBUG
 else
   CFLAGS += -O2
 endif
+
+ifdef PSL8
+  CFLAGS += -DPSL8
+endif
+ 
+ifdef PSL9
+  CFLAGS += -DPSL9
+endif

--- a/debug/Makefile.vars
+++ b/debug/Makefile.vars
@@ -17,10 +17,12 @@ else
   CFLAGS += -O2
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
- 
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/libcxl/Makefile.vars
+++ b/libcxl/Makefile.vars
@@ -19,10 +19,12 @@ else
  CFLAGS += -O2
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
- 
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/libcxl/libcxl.c
+++ b/libcxl/libcxl.c
@@ -1120,12 +1120,15 @@ static void *_psl_loop(void *ptr)
 {
 	struct cxl_afu_h *afu = (struct cxl_afu_h *)ptr;
 	uint8_t buffer[MAX_LINE_CHARS];
-	uint8_t op_size, function_code;
 	uint64_t addr;
 	uint16_t size, value;
 	uint32_t lvalue;
-	uint64_t llvalue, op1, op2;
+	uint64_t llvalue;
 	int rc;
+#ifdef PSL9
+	uint8_t op_size, function_code;
+	uint64_t op1, op2;
+#endif /*ifdef PSL9 */
 
 	if (!afu)
 		fatal_msg("NULL afu passed to libcxl.c:_psl_loop");

--- a/pslse/Makefile.vars
+++ b/pslse/Makefile.vars
@@ -17,10 +17,12 @@ else
   CFLAGS += -O2
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
- 
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/test/afu/Makefile.vars
+++ b/test/afu/Makefile.vars
@@ -18,3 +18,11 @@ ifdef DEBUG
 else
   CFLAGS += -O2
 endif
+
+ifdef PSL8
+  CFLAGS += -DPSL8
+endif
+ 
+ifdef PSL9
+  CFLAGS += -DPSL9
+endif

--- a/test/afu/Makefile.vars
+++ b/test/afu/Makefile.vars
@@ -19,10 +19,12 @@ else
   CFLAGS += -O2
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
- 
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/test/tests/Makefile
+++ b/test/tests/Makefile
@@ -15,7 +15,7 @@ CHECK_HEADER = $(shell echo \\\#include\ $(1) | $(CC) $(CFLAGS) -E - > /dev/null
 
 misc/cxl.h:
 ifeq ($(call CHECK_HEADER,"<misc/cxl.h>"),n)
-	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s http://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
+	$(call Q,CURL $(COMMON_DIR)/misc/cxl.h, mkdir $(COMMON_DIR)/misc 2>/dev/null; curl -o $(COMMON_DIR)/misc/cxl.h -s https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/include/uapi/misc/cxl.h)
 endif
 
 .SECONDEXPANSION:

--- a/test/tests/Makefile.vars
+++ b/test/tests/Makefile.vars
@@ -19,3 +19,11 @@ ifdef DEBUG
 else
  CFLAGS += -O2
 endif
+
+ifdef PSL8
+  CFLAGS += -DPSL8
+endif
+
+ifdef PSL9
+  CFLAGS += -DPSL9
+endif

--- a/test/tests/Makefile.vars
+++ b/test/tests/Makefile.vars
@@ -20,10 +20,12 @@ else
  CFLAGS += -O2
 endif
 
-ifdef PSL8
+ifeq ($(PSLVER),8)
   CFLAGS += -DPSL8
-endif
-
-ifdef PSL9
+else
+ifeq ($(PSLVER), 9)
   CFLAGS += -DPSL9
+else
+  $(error Must set PSLVER to 8 for PSL8 sim; to 9 for PSL9 sim)
+endif
 endif

--- a/test/tests/cas.c
+++ b/test/tests/cas.c
@@ -40,6 +40,7 @@ void usage(char *name)
 
 int main(int argc, char *argv[])
 {
+#ifdef PSL9
 	MachineConfig machine;
 	char *cacheline0, *cacheline1, *name;
 	uint64_t wed;
@@ -323,6 +324,6 @@ done:
 		cxl_afu_free(afu_m);
 	}
        
-
+#endif
 	return 0;
 }

--- a/test/tests/dma_memcopy.c
+++ b/test/tests/dma_memcopy.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* Description : memcopy.c
+/* Description : dma_memcopy.c
  *
  * This test performs memcopy using the Test AFU for validating pslse
  */
@@ -40,6 +40,7 @@ void usage(char *name)
 
 int main(int argc, char *argv[])
 {
+#ifdef PSL9
 	MachineConfig machine;
 	char *cacheline0, *cacheline1, *name;
 	uint64_t wed;
@@ -323,6 +324,6 @@ done:
 		cxl_afu_free(afu_m);
 	}
        
-
+#endif
 	return 0;
 }

--- a/test/tests/mmio.c
+++ b/test/tests/mmio.c
@@ -27,7 +27,9 @@
 #include <time.h>
 
 #include "libcxl.h"
+#ifdef PSL9
 #include "utils.h"
+#endif
 
 void usage(char *name)
 {
@@ -129,8 +131,10 @@ int main(int argc, char *argv[])
 		perror("FAILED:cxl_mmio_read64");
 		goto done;
 	}
+#ifdef PSL9
 	// WED is supposed to be in BE format in PSL, so got to shift?
 	wed_check = htonll(wed_check);
+#endif
 	if (wed != wed_check) {
 		printf("\nFAILED:WED mismatch!\n");
 		printf("\tExpected:0x%016"PRIx64"\n", wed);


### PR DESCRIPTION
A major update to PSLSE primarily around the CAPI 2.0 functions found in Power9.  We now require the environment variable PSLVER to be set to either 8 or 9 prior to executing the Makefiles