### PR TITLE
Build: Add central makefile to make build simpler for users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+#
+# Copyright 2018 International Business Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+subdirs = afu_driver/src pslse libcxl debug
+
+all clean:
+	@for d in $(subdirs) ; do		\
+		$(MAKE) -C $$d $@  || exit 1;	\
+	done					\
+
+help:
+	@cat QUICK_START
+


### PR DESCRIPTION
I think this is simpler for users, including ourselves, who currently need to walk through
your directory tree to get the stuff build or if we like to clean something up. Please consider
taking this. Thanks. The PSL8/9 stuff is going to change anyways as I have seen in your
other patch, so I stay away from printing errors/warnings if that stuff is not setup right.

Signed-off-by: Frank Haverkamp <haver@linux.vnet.ibm.com>