### PR TITLE
Issue #111 - prinf out message to console when DMA_WR or DMA_RD outst…

### DIFF
--- a/common/psl_interface.c
+++ b/common/psl_interface.c
@@ -1783,12 +1783,12 @@ psl_afu_dma0_req(struct AFU_EVENT *event,
 
 {
 	//check to be sure rd & wr credits are available, otherwise reject
-	//if ((event->dma0_req_type == DMA_DTYPE_RD_REQ) && (event->dma0_rd_credits <= 0))  {
-	//	printf("AFU IS OUT OF DMA RD CREDITS !!!!!! \n"); 
-	//	return PSL_NO_DMA_PORT_CREDITS; }
-	//if ((event->dma0_req_type != DMA_DTYPE_RD_REQ) && (event->dma0_wr_credits == 0)) {
-	//	printf("AFU IS OUT OF DMA WR CREDITS !!!!!! \n"); 
-	//	return PSL_NO_DMA_PORT_CREDITS; }
+	if ((event->dma0_req_type == DMA_DTYPE_RD_REQ) && (event->dma0_rd_credits <= 0))  {
+		printf("AFU IS OUT OF DMA RD CREDITS !!!!!! \n"); 
+		return PSL_NO_DMA_PORT_CREDITS; }
+	if ((event->dma0_req_type != DMA_DTYPE_RD_REQ) && (event->dma0_wr_credits == 0)) {
+		printf("AFU IS OUT OF DMA WR CREDITS !!!!!! \n"); 
+		return PSL_NO_DMA_PORT_CREDITS; }
 	if  (event->dma0_dvalid) {
 		printf("ALREADY A DMA CMD PENDING  !!!!!! \n");
 		return PSL_DOUBLE_DMA0_REQ;


### PR DESCRIPTION
…anding request count exceeds limit and AFU attempts to send another DMA_WR or DMA_RD request.